### PR TITLE
Fixing content-type in formheader

### DIFF
--- a/js/server.js
+++ b/js/server.js
@@ -75,7 +75,7 @@ var formHeaders = function(headerArr) {
         }
       }
     } else {
-      headers[field.toLowerCase()] = currentField[0];
+      headers[field.toLowerCase()] = currentLine[0];
     }
   }
   return headers


### PR DESCRIPTION
## Bug

When we uploading image to the system. Console printing content-type incorrect as below screen shoot. content-type is called 'filename' it should to be image type. It must to be 'image/jpeg' rather 'filename'

![image](https://cloud.githubusercontent.com/assets/1180128/15566143/d7731346-233c-11e6-87f1-f3ca5c5553a7.png)

Boundary:  ----WebKitFormBoundaryBqMXuWZcTxE7Kxe2
Headers:  { name: '"image-upload"',
  filename: '"wall.jpg"',
  'content-type': 'filename' }
## Bug Level

normal
## Fix

Done 
Included in this PR
## Test

Upload a image
![image](https://cloud.githubusercontent.com/assets/1180128/15566146/defeffda-233c-11e6-9269-fd8dc5bba95f.png)

Boundary:  ----WebKitFormBoundary1cDPIz29JjAvYomL
Headers:  { name: '"image-upload"',
  filename: '"wall.jpg"',
  'content-type': 'image/jpeg' }
